### PR TITLE
replace obsolete qVariantFromValue

### DIFF
--- a/lib/ofonocallbarring.cpp
+++ b/lib/ofonocallbarring.cpp
@@ -121,7 +121,7 @@ void OfonoCallBarring::requestVoiceIncoming()
 
 void OfonoCallBarring::setVoiceIncoming(const QString &barrings, const QString &password)
 {
-    m_if->setProperty("VoiceIncoming", qVariantFromValue(barrings), password);
+    m_if->setProperty("VoiceIncoming", QVariant::fromValue(barrings), password);
 }
 
 void OfonoCallBarring::requestVoiceOutgoing()
@@ -131,7 +131,7 @@ void OfonoCallBarring::requestVoiceOutgoing()
 
 void OfonoCallBarring::setVoiceOutgoing(const QString &barrings, const QString &password)
 {
-    m_if->setProperty("VoiceOutgoing", qVariantFromValue(barrings), password);
+    m_if->setProperty("VoiceOutgoing", QVariant::fromValue(barrings), password);
 }
 
 void OfonoCallBarring::propertyChanged(const QString& property, const QVariant& value)

--- a/lib/ofonocallforwarding.cpp
+++ b/lib/ofonocallforwarding.cpp
@@ -65,7 +65,7 @@ void OfonoCallForwarding::requestVoiceUnconditional()
 
 void OfonoCallForwarding::setVoiceUnconditional(const QString &property)
 {
-    m_if->setProperty("VoiceUnconditional", qVariantFromValue(property));
+    m_if->setProperty("VoiceUnconditional", QVariant::fromValue(property));
 }
 
 void OfonoCallForwarding::requestVoiceBusy()
@@ -75,7 +75,7 @@ void OfonoCallForwarding::requestVoiceBusy()
 
 void OfonoCallForwarding::setVoiceBusy(const QString &property)
 {
-    return m_if->setProperty("VoiceBusy", qVariantFromValue(property));
+    return m_if->setProperty("VoiceBusy", QVariant::fromValue(property));
 }
 
 void OfonoCallForwarding::requestVoiceNoReply()
@@ -85,7 +85,7 @@ void OfonoCallForwarding::requestVoiceNoReply()
 
 void OfonoCallForwarding::setVoiceNoReply(const QString &property)
 {
-    return m_if->setProperty("VoiceNoReply", qVariantFromValue(property));
+    return m_if->setProperty("VoiceNoReply", QVariant::fromValue(property));
 }
 
 void OfonoCallForwarding::requestVoiceNoReplyTimeout()
@@ -95,7 +95,7 @@ void OfonoCallForwarding::requestVoiceNoReplyTimeout()
 
 void OfonoCallForwarding::setVoiceNoReplyTimeout(ushort timeout)
 {
-    return m_if->setProperty("VoiceNoReplyTimeout", qVariantFromValue(timeout));
+    return m_if->setProperty("VoiceNoReplyTimeout", QVariant::fromValue(timeout));
 }
 
 void OfonoCallForwarding::requestVoiceNotReachable()
@@ -105,7 +105,7 @@ void OfonoCallForwarding::requestVoiceNotReachable()
 
 void OfonoCallForwarding::setVoiceNotReachable(const QString &property)
 {
-    return m_if->setProperty("VoiceNotReachable", qVariantFromValue(property));
+    return m_if->setProperty("VoiceNotReachable", QVariant::fromValue(property));
 }
 
 void OfonoCallForwarding::requestForwardingFlagOnSim()

--- a/lib/ofonocallsettings.cpp
+++ b/lib/ofonocallsettings.cpp
@@ -84,12 +84,12 @@ void OfonoCallSettings::requestVoiceCallWaiting()
 
 void OfonoCallSettings::setHideCallerId(const QString &preference)
 {
-    return m_if->setProperty("HideCallerId", qVariantFromValue(preference));
+    return m_if->setProperty("HideCallerId", QVariant::fromValue(preference));
 }
 
 void OfonoCallSettings::setVoiceCallWaiting(const QString &preference)
 {
-    return m_if->setProperty("VoiceCallWaiting", qVariantFromValue(preference));
+    return m_if->setProperty("VoiceCallWaiting", QVariant::fromValue(preference));
 }
 
 void OfonoCallSettings::requestPropertyComplete(bool success, const QString& property, const QVariant& value)

--- a/lib/ofonocallvolume.cpp
+++ b/lib/ofonocallvolume.cpp
@@ -86,10 +86,10 @@ void OfonoCallVolume::setPropertyFailed(const QString &property)
 
 void OfonoCallVolume::setSpeakerVolume(const quint8 &spvolume)
 {
-    m_if->setProperty("SpeakerVolume",qVariantFromValue(spvolume));
+    m_if->setProperty("SpeakerVolume",QVariant::fromValue(spvolume));
 }
 
 void OfonoCallVolume::setMicrophoneVolume(const quint8 &mpvolume)
 {
-    m_if->setProperty("MicrophoneVolume",qVariantFromValue(mpvolume));
+    m_if->setProperty("MicrophoneVolume",QVariant::fromValue(mpvolume));
 }

--- a/lib/ofonocellbroadcast.cpp
+++ b/lib/ofonocellbroadcast.cpp
@@ -81,7 +81,7 @@ bool OfonoCellBroadcast::powered() const
 
 void OfonoCellBroadcast::setPowered(bool b)
 {
-    m_if->setProperty("Powered",qVariantFromValue(b));
+    m_if->setProperty("Powered",QVariant::fromValue(b));
 }
 
 /*
@@ -95,7 +95,7 @@ QString OfonoCellBroadcast::topics() const
 
 void OfonoCellBroadcast::setTopics(const QString &list) const
 {
-    m_if->setProperty("Topics",qVariantFromValue(list));
+    m_if->setProperty("Topics",QVariant::fromValue(list));
 }
 
 QString OfonoCellBroadcast::errorName() const

--- a/lib/ofonoconnman.cpp
+++ b/lib/ofonoconnman.cpp
@@ -188,7 +188,7 @@ void OfonoConnMan::removeContext(const QString& contextpath)
 
     QList<QVariant> argumentList;
     QDBusObjectPath context (contextpath);
-    argumentList << qVariantFromValue(context);
+    argumentList << QVariant::fromValue(context);
     request.setArguments(argumentList);
     QDBusConnection::systemBus().callWithCallback(request, this,
                                         SLOT(removeContextResp()),

--- a/lib/ofonomessagemanager.cpp
+++ b/lib/ofonomessagemanager.cpp
@@ -149,7 +149,7 @@ void OfonoMessageManager::requestServiceCenterAddress()
 
 void OfonoMessageManager::setServiceCenterAddress(QString address)
 {
-    m_if->setProperty("ServiceCenterAddress", qVariantFromValue(address));
+    m_if->setProperty("ServiceCenterAddress", QVariant::fromValue(address));
 }
 
 void OfonoMessageManager::requestUseDeliveryReports()
@@ -159,7 +159,7 @@ void OfonoMessageManager::requestUseDeliveryReports()
 
 void OfonoMessageManager::setUseDeliveryReports(bool useDeliveryReports)
 {
-    m_if->setProperty("UseDeliveryReports", qVariantFromValue(useDeliveryReports));
+    m_if->setProperty("UseDeliveryReports", QVariant::fromValue(useDeliveryReports));
 }
 
 void OfonoMessageManager::requestBearer()
@@ -169,7 +169,7 @@ void OfonoMessageManager::requestBearer()
 
 void OfonoMessageManager::setBearer(QString bearer)
 {
-    m_if->setProperty("Bearer", qVariantFromValue(bearer));
+    m_if->setProperty("Bearer", QVariant::fromValue(bearer));
 }
 
 void OfonoMessageManager::requestAlphabet()
@@ -179,7 +179,7 @@ void OfonoMessageManager::requestAlphabet()
 
 void OfonoMessageManager::setAlphabet(QString alphabet)
 {
-    m_if->setProperty("Alphabet", qVariantFromValue(alphabet));
+    m_if->setProperty("Alphabet", QVariant::fromValue(alphabet));
 }
 
 

--- a/lib/ofonomessagewaiting.cpp
+++ b/lib/ofonomessagewaiting.cpp
@@ -59,7 +59,7 @@ QString OfonoMessageWaiting::voicemailMailboxNumber() const
 
 void OfonoMessageWaiting::setVoicemailMailboxNumber(QString mailboxnumber)
 {
-    m_if->setProperty("VoicemailMailboxNumber", qVariantFromValue(mailboxnumber));
+    m_if->setProperty("VoicemailMailboxNumber", QVariant::fromValue(mailboxnumber));
 }
 
 void OfonoMessageWaiting::setPropertyFailed(const QString& property)

--- a/lib/ofonomodem.cpp
+++ b/lib/ofonomodem.cpp
@@ -158,7 +158,7 @@ bool OfonoModem::powered() const
 
 void OfonoModem::setPowered(bool powered)
 {
-    m_if->setProperty("Powered", qVariantFromValue(powered));
+    m_if->setProperty("Powered", QVariant::fromValue(powered));
 }
 
 bool OfonoModem::online() const
@@ -168,7 +168,7 @@ bool OfonoModem::online() const
 
 void OfonoModem::setOnline(bool online)
 {
-    m_if->setProperty("Online", qVariantFromValue(online));
+    m_if->setProperty("Online", QVariant::fromValue(online));
 }
 
 bool OfonoModem::lockdown() const
@@ -178,7 +178,7 @@ bool OfonoModem::lockdown() const
 
 void OfonoModem::setLockdown(bool lockdown)
 {
-    m_if->setProperty("Lockdown", qVariantFromValue(lockdown));
+    m_if->setProperty("Lockdown", QVariant::fromValue(lockdown));
 }
 
 bool OfonoModem::emergency() const

--- a/lib/ofonoradiosettings.cpp
+++ b/lib/ofonoradiosettings.cpp
@@ -46,7 +46,7 @@ QString OfonoRadioSettings::technologyPreference() const
 
 void OfonoRadioSettings::setTechnologyPreference(QString preference)
 {
-    m_if->setProperty("TechnologyPreference", qVariantFromValue(preference));
+    m_if->setProperty("TechnologyPreference", QVariant::fromValue(preference));
 }
 
 QString OfonoRadioSettings::gsmBand() const
@@ -56,7 +56,7 @@ QString OfonoRadioSettings::gsmBand() const
 
 void OfonoRadioSettings::setGsmBand(QString gsmBand)
 {
-    m_if->setProperty("GsmBand", qVariantFromValue(gsmBand));
+    m_if->setProperty("GsmBand", QVariant::fromValue(gsmBand));
 }
 
 QString OfonoRadioSettings::umtsBand() const
@@ -66,7 +66,7 @@ QString OfonoRadioSettings::umtsBand() const
 
 void OfonoRadioSettings::setUmtsBand(QString umtsBand)
 {
-    m_if->setProperty("UmtsBand", qVariantFromValue(umtsBand));
+    m_if->setProperty("UmtsBand", QVariant::fromValue(umtsBand));
 }
 
 bool OfonoRadioSettings::fastDormancy() const
@@ -76,7 +76,7 @@ bool OfonoRadioSettings::fastDormancy() const
 
 void OfonoRadioSettings::setFastDormancy(bool fastDormancy)
 {
-    m_if->setProperty("FastDormancy", qVariantFromValue(fastDormancy));
+    m_if->setProperty("FastDormancy", QVariant::fromValue(fastDormancy));
 }
 
 void OfonoRadioSettings::setPropertyFailed(const QString& property)

--- a/lib/ofonosimmanager.cpp
+++ b/lib/ofonosimmanager.cpp
@@ -120,7 +120,7 @@ void OfonoSimManager::getIcon(quint8 id)
     request = QDBusMessage::createMethodCall("org.ofono",
 					     path(), m_if->ifname(),
 					     "GetIcon");
-    request << qVariantFromValue(id);
+    request << QVariant::fromValue(id);
 
     QDBusConnection::systemBus().callWithCallback(request, this,
 					SLOT(getIconResp(QByteArray)),
@@ -129,7 +129,7 @@ void OfonoSimManager::getIcon(quint8 id)
 
 void OfonoSimManager::setSubscriberNumbers(const QStringList &numbers)
 {
-    m_if->setProperty("SubscriberNumbers", qVariantFromValue(numbers));
+    m_if->setProperty("SubscriberNumbers", QVariant::fromValue(numbers));
 }
 
 bool OfonoSimManager::present() const

--- a/lib/ofonovoicecallmanager.cpp
+++ b/lib/ofonovoicecallmanager.cpp
@@ -248,7 +248,7 @@ void OfonoVoiceCallManager::privateChat(const QString &call)
                                              "PrivateChat");
 
     QList<QVariant>arg;
-    arg.append(qVariantFromValue(QDBusObjectPath(call)));
+    arg.append(QVariant::fromValue(QDBusObjectPath(call)));
     request.setArguments(arg);
     QDBusConnection::systemBus().callWithCallback(request, this,
                                         SLOT(privateChatResp(const QList<QDBusObjectPath>&)),

--- a/tests/test_ofonointerface.cpp
+++ b/tests/test_ofonointerface.cpp
@@ -39,11 +39,11 @@ private slots:
 	oi = new OfonoInterface("/phonesim", "org.ofono.Modem", OfonoGetAllOnStartup, this);
 
         if (oi->properties()["Powered"].toBool() == false) {
-            oi->setProperty("Powered", qVariantFromValue(true));
+            oi->setProperty("Powered", QVariant::fromValue(true));
             QTest::qWait(5000);
         }
         if (oi->properties()["Online"].toBool() == false) {
-            oi->setProperty("Online", qVariantFromValue(true));
+            oi->setProperty("Online", QVariant::fromValue(true));
             QTest::qWait(5000);
         }
     }
@@ -100,7 +100,7 @@ private slots:
         bool online_found;
         int lastSignalCount = -1;
     
-        oi->setProperty("Online", qVariantFromValue(false));
+        oi->setProperty("Online", QVariant::fromValue(false));
         while (spy_failed.count() == 0 && spy_changed.count() != lastSignalCount) {
             lastSignalCount = spy_changed.count();
             QTest::qWait(1000);
@@ -118,7 +118,7 @@ private slots:
         QCOMPARE(online_found, true);
         QCOMPARE(online, false);
 
-        oi->setProperty("Online", qVariantFromValue(true));
+        oi->setProperty("Online", QVariant::fromValue(true));
 
         lastSignalCount = -1;
         while (spy_failed.count() == 0 && spy_changed.count() != lastSignalCount) {
@@ -148,7 +148,7 @@ private slots:
         QSignalSpy spy_failed(oi, SIGNAL(setPropertyFailed(const QString &)));
         QVariantList list;
     
-        oi->setProperty("Manufacturer", qVariantFromValue(QString("Nokia")));
+        oi->setProperty("Manufacturer", QVariant::fromValue(QString("Nokia")));
         while (spy_changed.count() == 0 && spy_failed.count() == 0) {
             QTest::qWait(100);
         }


### PR DESCRIPTION
the replacement is QVariant::fromValue
see https://doc.qt.io/qt-5/qvariant-obsolete.html#qVariantFromValue this should allow build with Qt6